### PR TITLE
Add a notice to show development is no longer active and link to newer alternative.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# TyphoonLimbo is no longer in active development. Try out [LOOHP's Limbo](https://github.com/LOOHP/Limbo "LOOHP/Limbo") (1.19)
+---
 # TyphoonLimbo
 ## Lightweight minecraft limbo server
 


### PR DESCRIPTION
I've added a notice to the top of the README.md that tells the viewer that TyphoonLimbo is no longer in development and I've given a link to LOOHP's standalone limbo server. TyphoonLimbo ranks pretty high in google searches for limbo servers so it may be useful to some. 